### PR TITLE
Add UV instructions to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,14 @@ Pypi installation is the recommended route for most users::
   $ python3 -m pip install aiven-client
 
 
+Run without installing
+----------------------
+
+Use `uvx` from Astral's `uv` tool to run the CLI without installing it::
+
+  $ uvx --from aiven-client avn --help
+
+
 Build an RPM Package
 --------------------
 


### PR DESCRIPTION
## Summary
- document how to run `avn` without installing using `uvx`

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686f7a15b710832f86457296006e5d2f